### PR TITLE
[S1.2.3] Driver Requests UI

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -7,6 +7,8 @@ import { ForgotPassword } from './auth/pages/forgot-password/forgot-password';
 import { ResetPassword } from './auth/pages/reset-password/reset-password';
 import { Registration } from './auth/pages/registration/registration';
 import { ChangePasswordPage } from './pages/change-password/change-password';
+import { ChangeRequest} from './driver/pages/change-request/change-request';
+import { DriverRequestsPage } from './driver/pages/driver-requests/driver-requests';
 import { DriverHistory } from './history/pages/driver-history/driver-history';
 import { DriverAppointedRides } from './ride/pages/driver-appointed-rides/driver-appointed-rides';
 import { RideDetails } from './history/pages/ride-details/ride-details';
@@ -29,6 +31,8 @@ export const routes: Routes = [
     { path: 'reset-password', component: ResetPassword},
     { path: 'registration', component: Registration},
     { path: 'profile', component: ProfileInfo },
+    { path: 'change-request', component: ChangeRequest },
+    { path: 'driver-requests', component: DriverRequestsPage },
     { path: 'driver-registration', component: DriverRegistration },
     { path: 'change-password', component: ChangePasswordPage },
     { path: 'driver-history', component: DriverHistory },

--- a/frontend/src/app/driver/components/change-request-form/change-request-form.css
+++ b/frontend/src/app/driver/components/change-request-form/change-request-form.css
@@ -1,0 +1,49 @@
+.cr-container { padding: 24px; max-width: 980px; margin: 0 auto; }
+.cr-header { display:flex; justify-content:space-between; align-items:center; gap:16px; margin-bottom:18px }
+.cr-header h1 { margin:0; font-size:20px }
+.muted { color: #6c757d; font-size:13px }
+.cr-actions button { margin-left:8px }
+.cr-grid { display:grid; grid-template-columns: 280px 1fr; gap:20px }
+.cr-card { background:#fff; border-radius:8px; padding:16px; box-shadow: 0 6px 18px rgba(0,0,0,0.06) }
+.cr-profile .avatar-large { width:96px; height:96px; border-radius:50%; background:linear-gradient(135deg,#4e73df,#6f42c1); color:#fff; display:flex; align-items:center; justify-content:center; font-size:28px; font-weight:700; margin-bottom:12px }
+.cr-profile .name { margin:0 0 8px 0 }
+.cr-profile .avatar-large img { width:100%; height:100%; object-fit:cover; border-radius:50% }
+.avatar-row { display:flex; gap:12px; align-items:center; margin-bottom:12px }
+.avatar-block { text-align:center }
+.avatar-thumb { width:72px; height:72px; border-radius:8px; overflow:hidden; display:flex; align-items:center; justify-content:center; background:#f1f3f5 }
+.avatar-thumb img { width:100%; height:100%; object-fit:cover }
+.avatar-initial { font-size:22px; color:#fff; background:linear-gradient(135deg,#4e73df,#6f42c1); width:100%; height:100%; display:flex; align-items:center; justify-content:center }
+.avatar-label { font-size:12px; color:#6c757d; margin-top:6px }
+.avatar-thumb.changed { box-shadow:0 0 0 3px rgba(255,193,7,0.18); border-radius:10px }
+.chip { display:inline-block; background:#f1f3f5; padding:6px 10px; border-radius:999px; margin-right:6px; font-size:12px }
+.contact-list { list-style:none; padding:0; margin:12px 0 0 0 }
+.contact-list li { margin-bottom:8px }
+.cr-details h3 { margin-top:0 }
+.vehicle { display:flex; justify-content:space-between; gap:12px; align-items:center }
+.vehicle-left .plate { font-weight:700; font-size:18px; background:#f8f9fa; padding:8px 12px; border-radius:6px }
+.vehicle-left .model { color:#6c757d }
+.vehicle-right div { margin-bottom:6px }
+.notes h4 { margin-bottom:6px }
+
+@media (max-width:800px) {
+  .cr-grid { grid-template-columns: 1fr }
+}
+
+.admin-area { margin-top:18px }
+.admin-area textarea.form-control { resize:vertical }
+.result { padding:8px 10px; background:#f8f9fa; border-radius:6px; margin-top:8px }
+
+.cr-actions .btn { margin-left:8px }
+
+.diff-grid { border-radius:8px; overflow:hidden; }
+.diff-row { padding:8px 12px; display:flex; gap:12px; align-items:center }
+.diff-row.header { background:#f8f9fa; font-weight:600 }
+.diff-row .label { width:160px; color:#495057 }
+.diff-row .current, .diff-row .proposed { flex:1; color:#212529 }
+.diff-row .proposed.changed { background: #fff7e6; border-radius:6px; padding:6px }
+
+/* smaller avatar style for diff table */
+.diff-row .avatar-thumb { width:56px; height:56px; border-radius:8px; overflow:hidden; display:flex; align-items:center; justify-content:center; background:#f1f3f5 }
+.diff-row .avatar-thumb img { width:100%; height:100%; object-fit:cover }
+.diff-row .avatar-initial { font-size:18px; color:#fff; background:linear-gradient(135deg,#4e73df,#6f42c1); width:100%; height:100%; display:flex; align-items:center; justify-content:center }
+.diff-row .avatar-thumb.changed { box-shadow:0 0 0 3px rgba(255,193,7,0.18); border-radius:8px }

--- a/frontend/src/app/driver/components/change-request-form/change-request-form.html
+++ b/frontend/src/app/driver/components/change-request-form/change-request-form.html
@@ -1,0 +1,120 @@
+<div class="cr-container">
+  <header class="cr-header">
+    <div>
+      <h1>Admin — Change Request Review</h1>
+      <p class="muted small">Request: {{ requestMeta?.id }} • Submitted by: {{ requestMeta?.requestedBy }} • {{ requestMeta?.submittedAt | date:'short' }}</p>
+    </div>
+    <div class="cr-actions">
+      <button class="btn btn-outline-secondary" (click)="onBack()">Back</button>
+      <button class="btn btn-success" [disabled]="actionTaken" (click)="approveRequest()">Approve</button>
+      <button class="btn btn-danger" [disabled]="actionTaken" (click)="rejectRequest()">Reject</button>
+    </div>
+  </header>
+
+  <section class="cr-grid">
+    <aside class="cr-card cr-profile">
+      <div class="avatar-large">
+        <img *ngIf="changedDriver?.avatarUrl; else initialsLeft" [src]="changedDriver.avatarUrl" alt="profile avatar">
+        <ng-template #initialsLeft>{{ changedDriver.firstName?.charAt(0) }}{{ changedDriver.lastName?.charAt(0) }}</ng-template>
+      </div>
+      <h2 class="name">{{ changedDriver.firstName }} {{ changedDriver.lastName }}</h2>
+      <div class="meta">
+        <span class="chip">{{ changedDriver.role | uppercase }}</span>
+        <span class="chip">Active: {{ changedDriver.activeHours }}h</span>
+      </div>
+      <ul class="contact-list">
+        <li><strong>Phone:</strong> {{ changedDriver.phone }}</li>
+        <li><strong>Email:</strong> {{ changedDriver.email }}</li>
+        <li><strong>Address:</strong> {{ changedDriver.address }}</li>
+      </ul>
+    </aside>
+
+    <main class="cr-card cr-details">
+      <h3>Proposed vs Current</h3>
+
+      <div class="diff-grid">
+        <div class="diff-row header">
+          <div class="label">Field</div>
+          <div class="current">Current</div>
+          <div class="proposed">Proposed</div>
+        </div>
+
+        <div class="diff-row">
+          <div class="label">Avatar</div>
+          <div class="current">
+            <div class="avatar-thumb" [class.changed]="isAvatarChanged()">
+              <img *ngIf="originalDriver?.avatarUrl; else noCurSmall" [src]="originalDriver.avatarUrl" alt="current avatar">
+              <ng-template #noCurSmall><div class="avatar-initial">{{ originalDriver?.firstName?.charAt(0) || '?' }}</div></ng-template>
+            </div>
+          </div>
+          <div class="proposed">
+            <div class="avatar-thumb" [class.changed]="isAvatarChanged()">
+              <img *ngIf="changedDriver?.avatarUrl; else noPropSmall" [src]="changedDriver.avatarUrl" alt="proposed avatar">
+              <ng-template #noPropSmall><div class="avatar-initial">{{ changedDriver?.firstName?.charAt(0) || '?' }}</div></ng-template>
+            </div>
+          </div>
+        </div>
+
+        <div class="diff-row">
+          <div class="label">Name</div>
+          <div class="current">{{ originalDriver.firstName }} {{ originalDriver.lastName }}</div>
+          <div class="proposed" [class.changed]="isFieldChanged('firstName') || isFieldChanged('lastName')">{{ changedDriver.firstName }} {{ changedDriver.lastName }}</div>
+        </div>
+
+        <div class="diff-row">
+          <div class="label">Phone</div>
+          <div class="current">{{ originalDriver.phone }}</div>
+          <div class="proposed" [class.changed]="isFieldChanged('phone')">{{ changedDriver.phone }}</div>
+        </div>
+
+        <div class="diff-row">
+          <div class="label">Email</div>
+          <div class="current">{{ originalDriver.email }}</div>
+          <div class="proposed" [class.changed]="isFieldChanged('email')">{{ changedDriver.email }}</div>
+        </div>
+
+        <div class="diff-row">
+          <div class="label">Address</div>
+          <div class="current">{{ originalDriver.address }}</div>
+          <div class="proposed" [class.changed]="isFieldChanged('address')">{{ changedDriver.address }}</div>
+        </div>
+
+        <div class="diff-row">
+          <div class="label">Vehicle Model</div>
+          <div class="current">{{ originalDriver.vehicle?.model }}</div>
+          <div class="proposed" [class.changed]="isFieldChanged('vehicle.model')">{{ changedDriver.vehicle?.model }}</div>
+        </div>
+
+        <div class="diff-row">
+          <div class="label">License Plate</div>
+          <div class="current">{{ originalDriver.vehicle?.licensePlate }}</div>
+          <div class="proposed" [class.changed]="isFieldChanged('vehicle.licensePlate')">{{ changedDriver.vehicle?.licensePlate }}</div>
+        </div>
+
+        <div class="diff-row">
+          <div class="label">Seats</div>
+          <div class="current">{{ originalDriver.vehicle?.seats }}</div>
+          <div class="proposed" [class.changed]="isFieldChanged('vehicle.seats')">{{ changedDriver.vehicle?.seats }}</div>
+        </div>
+
+        <div class="diff-row">
+          <div class="label">Pet friendly</div>
+          <div class="current">{{ originalDriver.vehicle?.petFriendly ? 'Yes' : 'No' }}</div>
+          <div class="proposed" [class.changed]="isFieldChanged('vehicle.petFriendly')">{{ changedDriver.vehicle?.petFriendly ? 'Yes' : 'No' }}</div>
+        </div>
+
+        <div class="diff-row">
+          <div class="label">Baby friendly</div>
+          <div class="current">{{ originalDriver.vehicle?.babyFriendly ? 'Yes' : 'No' }}</div>
+          <div class="proposed" [class.changed]="isFieldChanged('vehicle.babyFriendly')">{{ changedDriver.vehicle?.babyFriendly ? 'Yes' : 'No' }}</div>
+        </div>
+      </div>
+
+      <section class="admin-area">
+        <h4>Admin notes</h4>
+        <textarea rows="4" class="form-control" [(ngModel)]="adminNotes" placeholder="Optional note for the user / audit log"></textarea>
+        <div class="result mt-2" *ngIf="resultMessage">{{ resultMessage }}</div>
+      </section>
+    </main>
+  </section>
+</div>

--- a/frontend/src/app/driver/components/change-request-form/change-request-form.spec.ts
+++ b/frontend/src/app/driver/components/change-request-form/change-request-form.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangeRequestForm } from './change-request-form';
+
+describe('ChangeRequestForm', () => {
+  let component: ChangeRequestForm;
+  let fixture: ComponentFixture<ChangeRequestForm>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChangeRequestForm]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChangeRequestForm);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/driver/components/change-request-form/change-request-form.ts
+++ b/frontend/src/app/driver/components/change-request-form/change-request-form.ts
@@ -1,0 +1,123 @@
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-change-request-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './change-request-form.html',
+  styleUrl: './change-request-form.css',
+})
+export class ChangeRequestForm implements OnInit {
+  @Input() originalDriver: any | null = null;
+  @Input() changedDriver: any | null = null;
+  @Input() requestMeta: any | null = null;
+  @Output() approve = new EventEmitter<any>();
+  @Output() reject = new EventEmitter<any>();
+
+  isMock = false;
+  adminNotes = '';
+  actionTaken: 'approved' | 'rejected' | null = null;
+  resultMessage = '';
+
+  private readonly MOCK_DRIVER = {
+    firstName: 'Ana',
+    lastName: 'Marković',
+    phone: '0601234567',
+    email: 'ana.markovic@example.com',
+    address: 'Bulevar oslobođenja 10, Novi Sad',
+    avatarUrl: 'assets/pfp/ana-avatar.jpg',
+    role: 'driver',
+    activeHours: 5,
+    vehicle: {
+      licensePlate: 'NS123AB',
+      model: 'VW Golf',
+      seats: 4,
+      type: 'Comfort',
+      petFriendly: true,
+      babyFriendly: false,
+    },
+  };
+
+  private readonly ORIGINAL_DRIVER = {
+    firstName: 'Ana',
+    lastName: 'Marković',
+    phone: '0609876543',
+    email: 'ana.old@example.com',
+    address: 'Jovana Cvijića 5, Novi Sad',
+    avatarUrl: 'assets/pfp/default-avatar-icon.jpg',
+    role: 'driver',
+    activeHours: 3,
+    vehicle: {
+      licensePlate: 'NS999ZZ',
+      model: 'Opel Astra',
+      seats: 4,
+      type: 'Standard',
+      petFriendly: false,
+      babyFriendly: true,
+    },
+  };
+
+  ngOnInit(): void {
+    if (!this.changedDriver) {
+      this.changedDriver = this.MOCK_DRIVER;
+      this.isMock = true;
+    }
+    if (!this.originalDriver) {
+      this.originalDriver = this.ORIGINAL_DRIVER;
+    }
+    if (!this.requestMeta) {
+      this.requestMeta = {
+        id: 'REQ-2026-001',
+        requestedBy: `${this.changedDriver.firstName} ${this.changedDriver.lastName}`,
+        submittedAt: new Date().toISOString(),
+        reason: 'Updated vehicle details and contact info',
+      };
+    }
+  }
+
+  private getValue(obj: any, path: string) {
+    try {
+      return path.split('.').reduce((acc, k) => (acc ? acc[k] : undefined), obj);
+    } catch {
+      return undefined;
+    }
+  }
+
+  isFieldChanged(path: string): boolean {
+    const a = this.getValue(this.originalDriver, path);
+    const b = this.getValue(this.changedDriver, path);
+    return a !== b;
+  }
+
+  isAvatarChanged(): boolean {
+    const a = this.getValue(this.originalDriver, 'avatarUrl');
+    const b = this.getValue(this.changedDriver, 'avatarUrl');
+    return a && b ? a !== b : Boolean(a) !== Boolean(b);
+  }
+
+  onBack(): void {
+    history.back();
+  }
+
+  approveRequest(): void {
+    if (this.actionTaken) return;
+    this.actionTaken = 'approved';
+    this.resultMessage = 'Approving request...';
+    setTimeout(() => {
+      this.resultMessage = `Request ${this.requestMeta?.id} approved.`;
+      this.approve.emit({ requestId: this.requestMeta?.id, notes: this.adminNotes });
+    }, 700);
+  }
+
+  rejectRequest(): void {
+    if (this.actionTaken) return;
+    this.actionTaken = 'rejected';
+    this.resultMessage = 'Rejecting request...';
+    setTimeout(() => {
+      this.resultMessage = `Request ${this.requestMeta?.id} rejected.`;
+      this.reject.emit({ requestId: this.requestMeta?.id, notes: this.adminNotes });
+    }, 700);
+  }
+}

--- a/frontend/src/app/driver/components/driver-requests-table/driver-requests-table.css
+++ b/frontend/src/app/driver/components/driver-requests-table/driver-requests-table.css
@@ -1,0 +1,15 @@
+.dr-table { padding: 8px }
+.dr-table .table { margin-bottom: 0 }
+.dr-table button { min-width: 72px }
+
+.status { display:inline-block; padding:4px 10px; border-radius:999px; font-weight:600; font-size:12px; text-transform:capitalize }
+.status.pending { background:#fff3cd; color:#856404; border:1px solid #ffeeba }
+.status.approved { background:#d4edda; color:#155724; border:1px solid #c3e6cb }
+.status.rejected { background:#f8d7da; color:#721c24; border:1px solid #f5c6cb }
+
+.clickable { cursor: pointer }
+.clickable:hover { text-decoration: underline }
+
+.avatar-cell { display:flex; align-items:center }
+.small-avatar { width:36px; height:36px; border-radius:50%; object-fit:cover; border:1px solid #e9ecef }
+.avatar-fallback { width:36px; height:36px; border-radius:50%; background:#dee2e6; display:flex; align-items:center; justify-content:center; font-weight:600 }

--- a/frontend/src/app/driver/components/driver-requests-table/driver-requests-table.html
+++ b/frontend/src/app/driver/components/driver-requests-table/driver-requests-table.html
@@ -1,0 +1,42 @@
+<div class="dr-table">
+  <div class="filter-row mb-2">
+    <label for="statusFilter" class="me-2">Filter:</label>
+    <select #statusFilter id="statusFilter" class="form-select form-select-sm w-auto d-inline-block" [value]="selectedStatus" (change)="onFilterChange(statusFilter.value)">
+      <option value="all">All</option>
+      <option value="pending">Pending</option>
+      <option value="approved">Approved</option>
+      <option value="rejected">Rejected</option>
+    </select>
+  </div>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Driver</th>
+        <th>Name</th>
+        <th>Request</th>
+        <th class="clickable" (click)="sortBy('submittedAt')">Submitted</th>
+        <th class="clickable" (click)="sortBy('status')">Status</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let r of filteredRequests">
+        <td>
+          <div class="avatar-cell">
+            <img *ngIf="r.changedDriver.avatarUrl || r.originalDriver.avatarUrl" [src]="r.changedDriver.avatarUrl || r.originalDriver.avatarUrl" alt="avatar" class="small-avatar" />
+            <div *ngIf="!(r.changedDriver.avatarUrl || r.originalDriver.avatarUrl)" class="avatar-fallback">{{ ((r.changedDriver.firstName || r.originalDriver.firstName) && (r.changedDriver.firstName || r.originalDriver.firstName).charAt(0)) || '?' }}</div>
+          </div>
+        </td>
+        <td>{{ r.changedDriver.firstName }} {{ r.changedDriver.lastName }}</td>
+        <td>{{ r.id }}</td>
+        <td>{{ r.submittedAt | date:'short' }}</td>
+        <td>
+          <span class="status {{ r.status }}">{{ r.status | titlecase }}</span>
+        </td>
+        <td>
+          <button class="btn btn-sm btn-primary" (click)="onView(r)">Review</button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/frontend/src/app/driver/components/driver-requests-table/driver-requests-table.spec.ts
+++ b/frontend/src/app/driver/components/driver-requests-table/driver-requests-table.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DriverRequestsTable } from './driver-requests-table';
+
+describe('DriverRequestsTable', () => {
+  let component: DriverRequestsTable;
+  let fixture: ComponentFixture<DriverRequestsTable>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DriverRequestsTable]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DriverRequestsTable);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/driver/components/driver-requests-table/driver-requests-table.ts
+++ b/frontend/src/app/driver/components/driver-requests-table/driver-requests-table.ts
@@ -1,0 +1,142 @@
+import { Component, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-driver-requests-table',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './driver-requests-table.html',
+  styleUrl: './driver-requests-table.css',
+})
+export class DriverRequestsTable {
+  @Output() viewRequest = new EventEmitter<any>();
+
+  requests = [
+    {
+      id: 'REQ-2026-101',
+      submittedAt: new Date(Date.now() - 2 * 86400000).toISOString(),
+      status: 'pending',
+      requestedBy: 'Ana Marković',
+      reason: 'Change contact and vehicle info',
+      originalDriver: {
+        firstName: 'Ana',
+        lastName: 'Marković',
+        phone: '0609876543',
+        role: 'driver',
+        email: 'ana.old@example.com',
+        address: 'Jovana Cvijića 5, Novi Sad',
+        avatarUrl: 'assets/pfp/default-avatar-icon.jpg',
+        activeHours: 3,
+        vehicle: { licensePlate: 'NS999ZZ', model: 'Opel Astra', seats: 4, petFriendly: false, babyFriendly: true },
+      },
+      changedDriver: {
+        firstName: 'Ana',
+        lastName: 'Marković',
+        phone: '0601234567',
+        role: 'driver',
+        email: 'ana.markovic@example.com',
+        address: 'Bulevar oslobođenja 10, Novi Sad',
+        avatarUrl: 'assets/pfp/default-avatar-icon.jpg',
+        
+        vehicle: { licensePlate: 'NS123AB', model: 'VW Golf', seats: 4, petFriendly: true, babyFriendly: false },
+      },
+    },
+    {
+      id: 'REQ-2026-102',
+      submittedAt: new Date(Date.now() - 86400000).toISOString(),
+      status: 'pending',
+      requestedBy: 'Marko Petrović',
+      reason: 'Enable pet friendly option',
+      originalDriver: {
+        firstName: 'Marko',
+        lastName: 'Petrović',
+        phone: '0615551234',
+        role: 'driver',
+        email: 'marko.petrovic@example.com',
+        address: 'Bulevar kralja Petra 3, Novi Sad',
+        avatarUrl: 'assets/pfp/default-avatar-icon.jpg',
+        activeHours: 3,
+        vehicle: { licensePlate: 'NS321BC', model: 'Fiat Tipo', seats: 4, petFriendly: false, babyFriendly: true },
+      },
+      changedDriver: {
+        firstName: 'Marko',
+        lastName: 'Petrović',
+        phone: '0615559999',
+        role: 'driver',
+        email: 'marko.new@example.com',
+        address: 'Bulevar kralja Petra 3, Novi Sad',
+        avatarUrl: 'assets/pfp/default-avatar-icon.jpg',
+        vehicle: { licensePlate: 'NS321BC', model: 'Fiat Tipo', seats: 4, petFriendly: true, babyFriendly: true },
+      },
+    },
+    {
+      id: 'REQ-2026-050',
+      submittedAt: new Date(Date.now() - 7 * 86400000).toISOString(),
+      status: 'approved',
+      requestedBy: 'Jelena Ilić',
+      reason: 'Update email and legal name',
+      originalDriver: {
+        firstName: 'Jelena',
+        lastName: 'Ilić',
+        phone: '062111222',
+        role: 'driver',
+        email: 'jelena.old@example.com',
+        address: 'Svetozara Miletića 12, Novi Sad',
+        avatarUrl:'assets/pfp/default-avatar-icon.jpg',
+        activeHours: 3,
+        vehicle: { licensePlate: 'NS555AA', model: 'Toyota Corolla', seats: 4, petFriendly: false, babyFriendly: false },
+      },
+      changedDriver: {
+        firstName: 'Jelena',
+        lastName: 'Ilić',
+        phone: '062111222',
+        role: 'driver',
+        email: 'jelena.ilic@example.com',
+        address: 'Svetozara Miletića 12, Novi Sad',
+        avatarUrl: 'assets/pfp/default-avatar-icon.jpg',
+        vehicle: { licensePlate: 'NS555AA', model: 'Toyota Corolla', seats: 4, petFriendly: false, babyFriendly: false },
+      },
+    },
+  ];
+  
+  selectedStatus: string = 'all';
+  sortField: string | null = null;
+  sortDirection: 'asc' | 'desc' = 'asc';
+  
+  get filteredRequests() {
+    let list = this.requests;
+    if (this.selectedStatus && this.selectedStatus !== 'all') {
+      list = list.filter(r => r.status === this.selectedStatus);
+    }
+    if (this.sortField) {
+      list = list.slice().sort((a: any, b: any) => {
+        const dir = this.sortDirection === 'asc' ? 1 : -1;
+        if (this.sortField === 'submittedAt') {
+          return (new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime()) * dir;
+        }
+        const field = this.sortField as string;
+        const av = (a as any)[field] ?? '';
+        const bv = (b as any)[field] ?? '';
+        return String(av).localeCompare(String(bv)) * dir;
+      });
+    }
+    return list;
+  }
+  
+  onFilterChange(status: string) {
+    this.selectedStatus = status;
+  }
+
+  sortBy(field: string) {
+    if (this.sortField === field) {
+      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortField = field;
+      this.sortDirection = 'asc';
+    }
+  }
+
+  onView(req: any) {
+    this.viewRequest.emit(req);
+  }
+}

--- a/frontend/src/app/driver/pages/change-request/change-request.css
+++ b/frontend/src/app/driver/pages/change-request/change-request.css
@@ -1,0 +1,36 @@
+.cr-container { padding: 24px; max-width: 980px; margin: 0 auto; }
+.cr-header { display:flex; justify-content:space-between; align-items:center; gap:16px; margin-bottom:18px }
+.cr-header h1 { margin:0; font-size:20px }
+.muted { color: #6c757d; font-size:13px }
+.cr-actions button { margin-left:8px }
+.cr-grid { display:grid; grid-template-columns: 280px 1fr; gap:20px }
+.cr-card { background:#fff; border-radius:8px; padding:16px; box-shadow: 0 6px 18px rgba(0,0,0,0.06) }
+.cr-profile .avatar-large { width:96px; height:96px; border-radius:50%; background:linear-gradient(135deg,#4e73df,#6f42c1); color:#fff; display:flex; align-items:center; justify-content:center; font-size:28px; font-weight:700; margin-bottom:12px }
+.cr-profile .name { margin:0 0 8px 0 }
+.chip { display:inline-block; background:#f1f3f5; padding:6px 10px; border-radius:999px; margin-right:6px; font-size:12px }
+.contact-list { list-style:none; padding:0; margin:12px 0 0 0 }
+.contact-list li { margin-bottom:8px }
+.cr-details h3 { margin-top:0 }
+.vehicle { display:flex; justify-content:space-between; gap:12px; align-items:center }
+.vehicle-left .plate { font-weight:700; font-size:18px; background:#f8f9fa; padding:8px 12px; border-radius:6px }
+.vehicle-left .model { color:#6c757d }
+.vehicle-right div { margin-bottom:6px }
+.notes h4 { margin-bottom:6px }
+
+.diff-grid { border-radius:8px; overflow:hidden; }
+.diff-row { padding:8px 12px; display:flex; gap:12px; align-items:center }
+.diff-row.header { background:#f8f9fa; font-weight:600 }
+.diff-row .label { width:160px; color:#495057 }
+.diff-row .current, .diff-row .proposed { flex:1; color:#212529 }
+.diff-row .proposed.changed { background: #fff7e6; border-radius:6px; padding:6px }
+
+@media (max-width:800px) {
+	.cr-grid { grid-template-columns: 1fr }
+}
+
+.admin-area { margin-top:18px }
+.admin-area textarea.form-control { resize:vertical }
+.result { padding:8px 10px; background:#f8f9fa; border-radius:6px; margin-top:8px }
+
+.cr-actions .btn { margin-left:8px }
+

--- a/frontend/src/app/driver/pages/change-request/change-request.html
+++ b/frontend/src/app/driver/pages/change-request/change-request.html
@@ -1,0 +1,7 @@
+<app-change-request-form
+  [originalDriver]="originalDriver"
+  [changedDriver]="changedDriver"
+  [requestMeta]="requestMeta"
+  (approve)="onApprove($event)"
+  (reject)="onReject($event)">
+</app-change-request-form>

--- a/frontend/src/app/driver/pages/change-request/change-request.spec.ts
+++ b/frontend/src/app/driver/pages/change-request/change-request.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangeRequest } from './change-request';
+
+describe('ChangeRequest', () => {
+  let component: ChangeRequest;
+  let fixture: ComponentFixture<ChangeRequest>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChangeRequest]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChangeRequest);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/driver/pages/change-request/change-request.ts
+++ b/frontend/src/app/driver/pages/change-request/change-request.ts
@@ -1,0 +1,109 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { ChangeRequestForm } from '../../components/change-request-form/change-request-form';
+
+@Component({
+  selector: 'app-change-request',
+  standalone: true,
+  imports: [CommonModule, ChangeRequestForm],
+  templateUrl: './change-request.html',
+  styleUrl: './change-request.css',
+})
+export class ChangeRequest implements OnInit {
+  changedDriver: any = null;
+  isMock = false;
+
+  private readonly MOCK_DRIVER = {
+    firstName: 'Ana',
+    lastName: 'Marković',
+    phone: '0601234567',
+    email: 'ana.markovic@example.com',
+    address: 'Bulevar oslobođenja 10, Novi Sad',
+    role: 'driver',
+    activeHours: 5,
+    vehicle: {
+      licensePlate: 'NS123AB',
+      model: 'VW Golf',
+      seats: 4,
+      type: 'Comfort',
+      petFriendly: true,
+      babyFriendly: false,
+    },
+  };
+  private readonly ORIGINAL_DRIVER = {
+    firstName: 'Ana',
+    lastName: 'Marković',
+    phone: '0609876543',
+    email: 'ana.old@example.com',
+    address: 'Jovana Cvijića 5, Novi Sad',
+    role: 'driver',
+    activeHours: 3,
+    vehicle: {
+      licensePlate: 'NS999ZZ',
+      model: 'Opel Astra',
+      seats: 4,
+      type: 'Standard',
+      petFriendly: false,
+      babyFriendly: true,
+    },
+  };
+  originalDriver: any = null;
+  requestMeta: any = null;
+  resultMessage = '';
+
+  constructor(private router: Router) {}
+
+  ngOnInit(): void {
+    const navigation = this.router.getCurrentNavigation();
+    this.changedDriver = navigation?.extras?.state?.['changedDriver'] || history.state?.['changedDriver'] || null;
+    this.originalDriver = navigation?.extras?.state?.['originalDriver'] || history.state?.['originalDriver'] || null;
+    if (!this.changedDriver) {
+      this.changedDriver = this.MOCK_DRIVER;
+      this.isMock = true;
+    }
+    if (!this.originalDriver) {
+      this.originalDriver = this.ORIGINAL_DRIVER;
+    }
+    if (!this.requestMeta) {
+      this.requestMeta = {
+        id: 'REQ-2026-001',
+        requestedBy: `${this.changedDriver.firstName} ${this.changedDriver.lastName}`,
+        submittedAt: new Date().toISOString(),
+        reason: 'Updated vehicle details and contact info',
+      };
+    }
+  }
+
+  private getValue(obj: any, path: string) {
+    try {
+      return path.split('.').reduce((acc, k) => (acc ? acc[k] : undefined), obj);
+    } catch {
+      return undefined;
+    }
+  }
+
+  isFieldChanged(path: string): boolean {
+    const a = this.getValue(this.originalDriver, path);
+    const b = this.getValue(this.changedDriver, path);
+    return a !== b;
+  }
+
+  onApprove(event: any): void {
+    this.resultMessage = `Approved ${event?.requestId || this.requestMeta?.id}`;
+  }
+
+  onReject(event: any): void {
+    this.resultMessage = `Rejected ${event?.requestId || this.requestMeta?.id}`;
+  }
+
+  submitRequest(): void {
+    this.router.navigate(['/profile'], {
+      state: { toastMessage: 'Your change request has been submitted and is pending admin approval.' },
+    });
+  }
+
+  goBack(): void {
+    this.router.navigate(['/profile']);
+  }
+}

--- a/frontend/src/app/driver/pages/driver-requests/driver-requests.css
+++ b/frontend/src/app/driver/pages/driver-requests/driver-requests.css
@@ -1,0 +1,1 @@
+.muted { color: #6c757d }

--- a/frontend/src/app/driver/pages/driver-requests/driver-requests.html
+++ b/frontend/src/app/driver/pages/driver-requests/driver-requests.html
@@ -1,0 +1,6 @@
+<div class="container py-4">
+  <h2>Driver Change Requests</h2>
+  <p class="muted">List of incoming change requests for drivers.</p>
+
+  <app-driver-requests-table (viewRequest)="openRequest($event)"></app-driver-requests-table>
+</div>

--- a/frontend/src/app/driver/pages/driver-requests/driver-requests.spec.ts
+++ b/frontend/src/app/driver/pages/driver-requests/driver-requests.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DriverRequestsPage } from './driver-requests';
+
+describe('DriverRequests', () => {
+  let component: DriverRequestsPage;
+  let fixture: ComponentFixture<DriverRequestsPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DriverRequestsPage]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DriverRequestsPage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/driver/pages/driver-requests/driver-requests.ts
+++ b/frontend/src/app/driver/pages/driver-requests/driver-requests.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { DriverRequestsTable } from '../../components/driver-requests-table/driver-requests-table';
+
+@Component({
+  selector: 'app-driver-requests',
+  standalone: true,
+  imports: [CommonModule, DriverRequestsTable],
+  templateUrl: './driver-requests.html',
+  styleUrl: './driver-requests.css',
+})
+export class DriverRequestsPage {
+  constructor(private router: Router) {}
+
+  openRequest(req: any) {
+    // navigate to change-request page with both original and changed driver
+    this.router.navigate(['/change-request'], {
+      state: { changedDriver: req.changedDriver, originalDriver: req.originalDriver },
+    });
+  }
+}

--- a/frontend/src/app/pages/driver-registration/driver-registration.spec.ts
+++ b/frontend/src/app/pages/driver-registration/driver-registration.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DriverRegistration } from './driver-registration';
+
+describe('DriverRegistration', () => {
+  let component: DriverRegistration;
+  let fixture: ComponentFixture<DriverRegistration>;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DriverRegistration]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DriverRegistration);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### Implementented
Admin review flow for driver change requests with side-by-side differences and approve/reject actions.
Avatar comparison, highlighted changed fields, admin notes, and working aprove. reject and back buttons.
Admin view of all the driver change requests.
Table shows profile picture, name, submitted date, request status and a button for preview.
Sorting toggles asc/desc when clicking column headers status and submitted (date). 
Mock data used until backend integration.

### User Story Coverage
S1.2.3 User Profile Managment

Closes #96 